### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,9 @@ AC_SUBST(LIBRCC_VERSION_INFO)
 LIBRCC_CVS=`cat VERSION | sed -e s/.*CVS.*/CVS/`
 if test "x$LIBRCC_CVS" = "xCVS"; then
 LIBRCC_CVS=1
-LIBRCC_CVS_DATE=`date +%y%m%d.%H`
+DATE_FMT="+%y%m%d.%H"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+LIBRCC_CVS_DATE=$(date -u -d "@$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$DATE_FMT" 2>/dev/null || date -u "$DATE_FMT")
 else 
 LIBRCC_CVS=0
 LIBRCC_CVS_DATE=0


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This date call only works with GNU date.  Do you want to support MacOSX, FreeBSD and such? Then I can modify the patch to work for these, too.

Also use UTC/gmtime to be independent of timezone.

This patch was done while working on reproducible builds for openSUSE.

Without this patch, we would get such a diff in our package build:
```diff
+++ new//usr/share/doc/packages/librcc-devel/examples/Makefile  2022-12-09 00:00:00.000000000 +0000
@@ -268,7 +268,7 @@
 LIBGUESS_LIBS = -lguess
 LIBOBJS =
 LIBRCC_CVS = 1
-LIBRCC_CVS_DATE = 230117.18
+LIBRCC_CVS_DATE = 390219.07
```